### PR TITLE
Update Set-TdChange.ps1

### DIFF
--- a/TOPdeskPS/functions/Change Management/Set-TdChange.ps1
+++ b/TOPdeskPS/functions/Change Management/Set-TdChange.ps1
@@ -1,4 +1,4 @@
-﻿function Set-TdChange {
+function Set-TdChange {
     <#
 .SYNOPSIS
     Sort of sets a change, this is poorly supported by TOPdesk :/
@@ -32,7 +32,7 @@
         Write-PsfMessage "ParameterSetName: $($PsCmdlet.ParameterSetName)" -Level InternalComment
         Write-PSfMessage "PSBoundParameters: $($PSBoundParameters | Out-String)" -Level InternalComment
 
-        $uri = "$(Get-TdUrl)/tas/api/operatorchanges/$ChangeId"
+        $uri = "$(Get-TdUrl)/tas/api/operatorChanges/$ChangeId"
         $body = $BodyInput
 
         if (-not (Test-PSFShouldProcess -PSCmdlet $PSCmdlet -Target $uri -Action 'Sending Request')) {
@@ -40,8 +40,9 @@
         }
         $methodParams = @{
             Uri = $uri
-            Body = ($body | ConvertTo-Json)
-            Method = $MethodName
+            Body = (ConvertTo-Json $body)
+            Method = 'Patch'
+            ContentType = 'application/json-patch+json'
         }
         $res = Invoke-TdMethod @methodParams
         $res


### PR DESCRIPTION
Fix according to TOPdesk documentation:
- URI: operatorchanges => operatorChanges
- Body = ($body | ConvertTo-Json) => Body = (ConvertTo-Json $body). This preserves arrays when converting to JSON.
- Method: Patch
- ContentType: application/json-patch+json

For example, the following now works:

$changeObject = [PSCustomObject]@{
        op = 'replace'
        path = '/object'
        value = $tdObjectId
}
$body = @($changeObject)
$dummy = Set-TdChange -ChangeId $tdChange.number -BodyInput $body


### Requirements

* This template is required. Any request that does not include enough information may be closed at the maintainers' discretion.
* Have you (put an X between the brackets on each line to confirm):
    * [ ] Written new test cases to ensure no regression bugs occur?
    * [ ] Ensured all test cases are now passing?
    * [ ] Ensured that PowerShell Script Analyser issues and warnings are completely resolved?
    * [ ] Updated any help or documentation that may be impacted by your changes?

### Description of the Change

[ We must be able to understand the design of your change from this description. If we cannot get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. ]

### Testing

[ Please describe the testing you have performed ]

### Associated/Resolved Issues

[ Enter any applicable issues here ]

> Note: By creating a pull request, you are expected to comply with this project's Code of Conduct.

<!--

    This template is based upon the work by the Atom project, https://github.com/atom/atom/

-->
