### PR TITLE
Support PS version 7+ in Invoke-TdMethod -File

### DIFF
--- a/TOPdeskPS/functions/General API/Invoke-TdMethod.ps1
+++ b/TOPdeskPS/functions/General API/Invoke-TdMethod.ps1
@@ -104,14 +104,12 @@
                 }
                 Write-PSFMessage -Level InternalComment -Message "Params to be bassed to IRM: $($params.Keys -join ",")"
                 Invoke-RestMethod @Params
-
             }
 
 
             'File' {
-
                 switch ($PSVersionTable.PSVersion.Major) {
-                    5 {
+                    { $_ -le 5 } {
                         #TOPdesk always want a multipart request for files from what I've seen.
 
                         # Use fiddler to troubleshoot this.
@@ -130,7 +128,6 @@
                         else {
                             $ContentType = "application/octet-stream"
                         }
-
 
 
                         $fileBin = [System.IO.File]::ReadAllBytes($File)
@@ -172,12 +169,10 @@
                             Headers = $Headers
                         }
                         Invoke-RestMethod @params
-
                     }
 
 
-                    6 {
-
+                    { $_ -ge 6 } {
                         $form = @{
                             file = Get-Item $file
                         }
@@ -193,13 +188,8 @@
                             Headers = $Headers
                         }
                         Invoke-RestMethod @params
-
                     }
-
-
-
                 }
-
             }
         }
     }


### PR DESCRIPTION
### Description of the Change

`Invoke-TdMethod -File` was non-functional on PowerShell version 7.

Instead of just checking for versions 5 or 6 of PowerShell, we now check for "5 or less" and "6 or greater" so that PowerShell 7, and future versions, are supported.

### Testing

Tested the new switch syntax on both 5.1 and 7.x.

### Associated/Resolved Issues

Resolves https://github.com/AndrewPla/TOPdeskPS/issues/120


